### PR TITLE
Improve performance by skipping bytes instead of parsing again on a second pass (or first)

### DIFF
--- a/src/main/java/edu/tufts/eaftan/hprofparser/parser/HprofParser.java
+++ b/src/main/java/edu/tufts/eaftan/hprofparser/parser/HprofParser.java
@@ -789,25 +789,4 @@ public class HprofParser {
 
     return id;
   }
-
- 
-  /* Utility */
-
-  private int mySkipBytes(int n, DataInput in) throws IOException {
-    int bytesRead = 0;
-    
-    try {
-      while (bytesRead < n) {
-        in.readByte();
-        bytesRead++;
-      }
-    } catch (EOFException e) {
-      // expected
-    }
-    
-    return bytesRead;
-  }
-
-
 }
-


### PR DESCRIPTION
For 2GB heap dump:
```bash
$ wc large.hprof 
   2545071   20258239 2438383468 large.hprof
```

Baseline performance (ParallelGC is much better):
```bash
$ time java -Xmx5G -XX:+UseParallelGC -cp $CLASSPATH edu.tufts.eaftan.hprofparser.Parse --handler=edu.tufts.eaftan.hprofparser.handler.NullRecordHandler large.hprof

real	0m34.781s
user	0m39.424s
sys	0m1.759s

$ time java -Xmx5G -XX:+UseG1GC -cp $CLASSPATH edu.tufts.eaftan.hprofparser.Parse --handler=edu.tufts.eaftan.hprofparser.handler.NullRecordHandler large.hprof

real	0m42.754s
user	0m57.383s
sys	0m3.121s
```

After optimizations:

```bash
$ time java -Xmx5G -XX:+UseParallelGC -cp $CLASSPATH edu.tufts.eaftan.hprofparser.Parse --handler=edu.tufts.eaftan.hprofparser.handler.NullRecordHandler large.hprof

real	0m24.539s
user	0m25.911s
sys	0m1.373s
```

Other possible optimizations:
* Increase buffer size for `BufferedInputStream`. Tried it, at most 200 milliseconds gain (variability is bigger).
* Change `primArrayDump` interface to use native primitive arrays instead of `Value<?>[]`. It gives significant gain: 16 seconds against 24 seconds.